### PR TITLE
Update minimessage format docs link

### DIFF
--- a/transfer-velocity/src/main/resources/config.toml
+++ b/transfer-velocity/src/main/resources/config.toml
@@ -7,7 +7,7 @@ enabled=true
 # Messages
 [messages]
     # MiniMessage formatted string:
-    # Link: https://docs.adventure.kyori.net/minimessage.html#format
+    # Link: https://docs.adventure.kyori.net/minimessage/format
     # Placeholders: <player>, <old_server>, <new_server>
     quit-message-new-server="<yellow><player> left <old_server> and joined <new_server>.</yellow>"
     quit-message="<yellow><player> left the game</yellow>"


### PR DESCRIPTION
As per KyoriPowered/adventure-docs#45, the documentation for minimessage was split up into two pages and no longer uses a fragment in the link. While old links still continue to work, they don't directly bring the user directly to the format page as before